### PR TITLE
Fix Having Duplicate Code, Each Method In IMDB API

### DIFF
--- a/app/models/imdb.rb
+++ b/app/models/imdb.rb
@@ -2,26 +2,23 @@ class Imdb
 	include HTTParty
 	base_uri 'myapifilms.com'
 
-	@@my_api_films_token = ENV["my_api_films"]
+	@@options = { 
+		token: ENV["my_api_films"] 
+	}
 
 	def self.find_by_title(options = {})
-		options[:token] = @@my_api_films_token
+		@@options.merge!(options)
 
-		get("/imdb", query: options)
+		get("/imdb", query: @@options)
 	end
 
 	def self.find(imdb_id)
-		options = { 
-			token: @@my_api_films_token,
-			idIMDB: imdb_id
-		}
+		@@options[:idIMDB] = imdb_id
 		
-		get("/imdb", query: options)
+		get("/imdb", query: @@options)
 	end
 
 	def self.top_movies
-		options = { token: @@my_api_films_token }
-
-		get("/imdb/top", query: options)
+		get("/imdb/top", query: @@options)
 	end
 end


### PR DESCRIPTION
Fix having to use the same code at the start of each of the methods in IMDB API because the query to the API uses hashes for each of the options and there is a constant of having a token for each query.
